### PR TITLE
chore: bump minimum python version to 3.9

### DIFF
--- a/.cursor/rules/project.mdc
+++ b/.cursor/rules/project.mdc
@@ -11,7 +11,7 @@ RustShogi is a high-performance Shogi library implemented in Rust. It provides P
 - **Language**: Rust 2021 Edition
 - **Version**: 0.1.0
 - **License**: MIT License
-- **Python Support**: Python 3.8+
+- **Python Support**: Python 3.9+
 - **Build System**: Cargo (using maturin for Python packaging)
 
 ## Key Features
@@ -162,7 +162,7 @@ Test files for each module exist in the `tests/` directory:
 ## Development Environment
 
 - Rust 2021 Edition
-- Python 3.8+
+- Python 3.9+
 - maturin (Python package build)
 - Windows/Linux/macOS support
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
     <img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="License: MIT">
   </a>
   <img src="https://img.shields.io/badge/Rust-2021-orange.svg" alt="Rust 2021">
-  <img src="https://img.shields.io/badge/Python-3.8+-blue.svg" alt="Python 3.8+">
+  <img src="https://img.shields.io/badge/Python-3.9+-blue.svg" alt="Python 3.9+">
   <a href="https://pepy.tech/projects/rustshogi"><img src="https://static.pepy.tech/personalized-badge/rustshogi?period=total&units=INTERNATIONAL_SYSTEM&left_color=BLACK&right_color=BLUE&left_text=downloads" alt="PyPI Downloads"></a>
 </p>
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -6,7 +6,7 @@ rustshogi is distributed as a Python package.
 Requirements
 ------------
 
-* Python 3.8 or higher
+* Python 3.9 or higher
 * Windows, macOS, Linux (x86_64)
 
 Installation with pip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "rustshogi"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",


### PR DESCRIPTION
Python 3.8のサポートを終了し、最小バージョンをPython 3.9に引き上げました。

**原因**
Dependabotによるセキュリティアップデートにおいて、`requests` や `sphinx` の最新版がPython 3.8のサポートを終了しているため、依存関係の解決エラーが発生していました。

**対策**
Python 3.8は2024年10月にEOL（サポート終了）を迎えているため、パッケージの動作要件をPython 3.9以上に引き上げました。
- `pyproject.toml` の `requires-python` を更新
- `README.md` のバッジと説明を更新
- ドキュメント (`docs/source/installation.rst`) の要件を更新
- Cursorルール (`.cursor/rules/project.mdc`) を更新

変更後も全てのテストが正常に通過することを確認済みです。

---
*PR created automatically by Jules for task [162749007494462084](https://jules.google.com/task/162749007494462084) started by @applyuser160*